### PR TITLE
TC-624 Manifest Error

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,11 +268,10 @@ importers:
   solution/ui:
     dependencies:
       d3: 5.16.0
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-image: 2.4.14
       gatsby-legacy-polyfills: 0.4.0
       gatsby-plugin-less: 3.2.9_gatsby@2.30.1+less@3.12.2
-      gatsby-plugin-manifest: 2.4.22_gatsby@2.30.1
       gatsby-plugin-offline: 3.2.22_gatsby@2.30.1
       gatsby-plugin-pnpm: 1.2.5_gatsby@2.30.1
       gatsby-plugin-react-helmet: 3.3.10_gatsby@2.30.1+react-helmet@6.1.0
@@ -342,7 +341,6 @@ importers:
       gatsby-legacy-polyfills: 0.4.0
       gatsby-plugin-eslint: ^2.0.8
       gatsby-plugin-less: ^3.2.4
-      gatsby-plugin-manifest: ^2.4.9
       gatsby-plugin-offline: ^3.2.7
       gatsby-plugin-pnpm: ^1.2.5
       gatsby-plugin-react-helmet: ^3.3.2
@@ -369,7 +367,7 @@ importers:
       semantic-ui-react: ^0.88.2
       serverless-deployment-bucket: ^1.1.2
       sharp: ^0.27.0
-lockfileVersion: 5.2
+lockfileVersion: 5.1
 packages:
   /2-thenable/1.0.0:
     dependencies:
@@ -3618,7 +3616,7 @@ packages:
       jest-haste-map: 24.9.0
       jest-message-util: 24.9.0
       jest-regex-util: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       jest-resolve-dependencies: 24.9.0
       jest-runner: 24.9.0
       jest-runtime: 24.9.0
@@ -3654,7 +3652,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-message-util: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       jest-resolve-dependencies: 26.3.0
       jest-runner: 26.3.0
       jest-runtime: 26.3.0
@@ -3754,7 +3752,7 @@ packages:
       istanbul-lib-source-maps: 3.0.6
       istanbul-reports: 2.2.7
       jest-haste-map: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       jest-runtime: 24.9.0
       jest-util: 24.9.0
       jest-worker: 24.9.0
@@ -3785,7 +3783,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 26.3.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       jest-util: 26.3.0
       jest-worker: 26.3.0
       slash: 3.0.0
@@ -4437,7 +4435,7 @@ packages:
       error-stack-parser: 2.0.6
       string-width: 2.1.1
       strip-ansi: 3.0.1
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
@@ -4452,7 +4450,7 @@ packages:
       react-refresh: 0.8.3
       schema-utils: 2.7.1
       source-map: 0.7.3
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-dev-server: 3.11.1_webpack@4.44.2
       webpack-hot-middleware: 2.25.0
     dev: false
@@ -6629,7 +6627,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     engines:
       node: '>= 8.9'
@@ -6751,7 +6749,7 @@ packages:
       integrity: sha512-JrB9ZASlMAfkRF+5NdgoQxgenhJxzXFEO1vrqsSDJdzLrC38L2wrvXF9mm1YLbrehkZxcrNz9UYDyARP4jaY9g==
   /babel-plugin-remove-graphql-queries/2.14.0_gatsby@2.30.1:
     dependencies:
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
     dev: false
     engines:
       node: '>=10.13.0'
@@ -8639,7 +8637,7 @@ packages:
       postcss-modules-values: 1.3.0
       postcss-value-parser: 3.3.1
       source-list-map: 2.0.1
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     engines:
       node: '>= 6.9.0 <7.0.0 || >= 8.9.0'
@@ -10314,7 +10312,7 @@ packages:
       object-assign: 4.1.1
       object-hash: 1.3.1
       rimraf: 2.7.1
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     deprecated: This loader has been deprecated. Please use eslint-webpack-plugin
     dev: false
     peerDependencies:
@@ -11259,7 +11257,7 @@ packages:
     dependencies:
       loader-utils: 1.4.0
       schema-utils: 0.4.7
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     engines:
       node: '>= 4.3 < 5.0.0 || >= 5.10'
@@ -11921,7 +11919,7 @@ packages:
       case: 1.6.3
       date-fns: 2.15.0
       formik: 2.1.5_react@16.13.1
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-design-tokens: 2.0.10
       lodash.sample: 4.2.1
       prop-types: 15.7.2
@@ -11991,7 +11989,7 @@ packages:
     dependencies:
       eslint: 7.13.0
       eslint-loader: 4.0.2_eslint@7.13.0
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
     dev: true
     peerDependencies:
       eslint: ^6.6.0
@@ -12002,7 +12000,7 @@ packages:
   /gatsby-plugin-less/3.2.9_gatsby@2.30.1+less@3.12.2:
     dependencies:
       '@babel/runtime': 7.11.2
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       less: 3.12.2
       less-loader: 5.0.0_less@3.12.2
     dev: false
@@ -12013,25 +12011,11 @@ packages:
       less: ^3.0.0
     resolution:
       integrity: sha512-JcUpHv53WdgSCKxaatqGTc/zRqJ6hc39W62ClLPLHLTtm7fa1x8RCrzuBu1kFLJl6uRkZfbAg4DSKuc50KMNNQ==
-  /gatsby-plugin-manifest/2.4.22_gatsby@2.30.1:
-    dependencies:
-      '@babel/runtime': 7.11.2
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
-      gatsby-core-utils: 1.3.15
-      semver: 5.7.1
-      sharp: 0.25.4
-    dev: false
-    engines:
-      node: '>=10.13.0'
-    peerDependencies:
-      gatsby: ^2.4.0
-    resolution:
-      integrity: sha512-pdIcT3ei9RMDoUupmNvpEtg/2jCsuN1tT+6HeIv8WudMEXFWrbOuETD3mZL4D2u/NJ4D1/rXhHlzxMZkbu7CIQ==
   /gatsby-plugin-offline/3.2.22_gatsby@2.30.1:
     dependencies:
       '@babel/runtime': 7.11.2
       cheerio: 1.0.0-rc.3
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-core-utils: 1.3.15
       glob: 7.1.6
       idb-keyval: 3.2.0
@@ -12050,7 +12034,7 @@ packages:
       '@sindresorhus/slugify': 1.1.0
       chokidar: 3.5.0
       fs-exists-cached: 1.0.0
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-page-utils: 0.7.0
       gatsby-telemetry: 1.8.0
       globby: 11.0.2
@@ -12064,7 +12048,7 @@ packages:
       integrity: sha512-YnYc/ZvVVlhHH9RBwigkcTbd9uRVXrupyVFFk/Ee3isO+TtVjVCBrcDBORpHBcBruq5r6/ifTqh4T5kKjqtM3g==
   /gatsby-plugin-pnpm/1.2.5_gatsby@2.30.1:
     dependencies:
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       lodash.uniq: 4.5.0
     dev: false
     peerDependencies:
@@ -12074,7 +12058,7 @@ packages:
   /gatsby-plugin-react-helmet/3.3.10_gatsby@2.30.1+react-helmet@6.1.0:
     dependencies:
       '@babel/runtime': 7.11.2
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       react-helmet: 6.1.0_react@16.13.1
     dev: false
     engines:
@@ -12087,7 +12071,7 @@ packages:
   /gatsby-plugin-sass/2.3.12_gatsby@2.30.1+node-sass@4.14.1:
     dependencies:
       '@babel/runtime': 7.11.2
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       node-sass: 4.14.1
       sass-loader: 7.3.1
     dev: false
@@ -12104,7 +12088,7 @@ packages:
       async: 3.2.0
       bluebird: 3.7.2
       fs-extra: 9.0.1
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-core-utils: 1.8.0
       gatsby-telemetry: 1.8.0
       got: 10.7.0
@@ -12145,7 +12129,7 @@ packages:
       integrity: sha512-1mf7zrFVE5UEut+3YRnb3N2XareM0Xk4Mfzw0K89ASqWT4R4QaEIxycsjPERBZMFy0GLWt8e0Hl93Wwn+eefwg==
   /gatsby-plugin-utils/0.7.0_gatsby@2.30.1:
     dependencies:
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       joi: 17.3.0
     dev: false
     engines:
@@ -12156,7 +12140,7 @@ packages:
       integrity: sha512-fClolFlWQvczukRQhLfdFtz9GXIehgf567HJbggC2oPkVT0NCwwNPAAjVq1CcmxQE8k/kcp7kxQVc86pVcWuzA==
   /gatsby-plugin-webpack-size/1.0.0_gatsby@2.30.1:
     dependencies:
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       size-plugin: 1.2.0
     dev: true
     peerDependencies:
@@ -12340,7 +12324,7 @@ packages:
       chokidar: 3.4.0
       file-type: 12.4.2
       fs-extra: 8.1.0
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-core-utils: 1.3.15
       got: 9.6.0
       md5-file: 3.2.3
@@ -12407,7 +12391,7 @@ packages:
       '@babel/runtime': 7.11.2
       bluebird: 3.7.2
       fs-extra: 8.1.0
-      gatsby: 2.30.1_react-dom@16.13.1+react@16.13.1
+      gatsby: 2.30.1_e838f882ea48480c14baeb40ecd8176c
       gatsby-plugin-sharp: 2.12.0_gatsby@2.30.1
       potrace: 2.1.8
       probe-image-size: 4.1.1
@@ -12421,7 +12405,7 @@ packages:
       gatsby-plugin-sharp: ^2.0.0-beta.3
     resolution:
       integrity: sha512-f9VQVs7WFv3js6oGReJX1WUYxYTfE9CT+VV8tJHJ+uiUQ8JpDHRq4hjDGdhfFgaPjsmdb7Y4gUVOsLsWLitXOg==
-  /gatsby/2.30.1_react-dom@16.13.1+react@16.13.1:
+  /gatsby/2.30.1_e838f882ea48480c14baeb40ecd8176c:
     dependencies:
       '@babel/code-frame': 7.12.11
       '@babel/core': 7.12.10
@@ -12569,7 +12553,7 @@ packages:
       util.promisify: 1.0.1
       uuid: 3.4.0
       v8-compile-cache: 1.1.2
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-dev-middleware: 3.7.3_webpack@4.44.2
       webpack-dev-server: 3.11.1_webpack@4.44.2
       webpack-hot-middleware: 2.25.0
@@ -12583,6 +12567,7 @@ packages:
       node: '>=10.13.0'
     hasBin: true
     peerDependencies:
+      gatsby: '*'
       react: ^16.4.2
       react-dom: ^16.4.2
     requiresBuild: true
@@ -14859,7 +14844,7 @@ packages:
       jest-get-type: 24.9.0
       jest-jasmine2: 24.9.0
       jest-regex-util: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       jest-util: 24.9.0
       jest-validate: 24.9.0
       micromatch: 3.1.10
@@ -14885,7 +14870,7 @@ packages:
       jest-get-type: 26.3.0
       jest-jasmine2: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       jest-util: 26.3.0
       jest-validate: 26.3.0
       micromatch: 4.0.2
@@ -15272,7 +15257,7 @@ packages:
       integrity: sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==
   /jest-pnp-resolver/1.2.2_jest-resolve@24.9.0:
     dependencies:
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
     dev: true
     engines:
       node: '>=6'
@@ -15285,7 +15270,7 @@ packages:
       integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
   /jest-pnp-resolver/1.2.2_jest-resolve@26.3.0:
     dependencies:
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
     dev: true
     engines:
       node: '>=6'
@@ -15328,7 +15313,7 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-j5rZ2BUh8vVjJZ7bpgCre0t6mbFLm5BWfVhYb1H35A3nbPN3kepzMqkMnKXPhwyLIVwn25uYkv6LHc2/Xa1sGw==
-  /jest-resolve/24.9.0:
+  /jest-resolve/24.9.0_jest-resolve@24.9.0:
     dependencies:
       '@jest/types': 24.9.0
       browser-resolve: 1.11.3
@@ -15338,9 +15323,11 @@ packages:
     dev: true
     engines:
       node: '>= 6'
+    peerDependencies:
+      jest-resolve: '*'
     resolution:
       integrity: sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
-  /jest-resolve/26.3.0:
+  /jest-resolve/26.3.0_jest-resolve@26.3.0:
     dependencies:
       '@jest/types': 26.3.0
       chalk: 4.1.0
@@ -15353,6 +15340,8 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      jest-resolve: '*'
     resolution:
       integrity: sha512-+oKVWDkXjdZ4Xciuxv+M5e5v/Z3RLjrKIzen9tq3IO6HpzsLf9Mk3rET5du1uU8iVUCvz4/1PmjzNF50Uc7l2A==
   /jest-runner/24.9.0:
@@ -15370,7 +15359,7 @@ packages:
       jest-jasmine2: 24.9.0
       jest-leak-detector: 24.9.0
       jest-message-util: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       jest-runtime: 24.9.0
       jest-util: 24.9.0
       jest-worker: 24.9.0
@@ -15397,7 +15386,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-leak-detector: 26.3.0
       jest-message-util: 26.3.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       jest-runtime: 26.3.0
       jest-util: 26.3.0
       jest-worker: 26.3.0
@@ -15425,7 +15414,7 @@ packages:
       jest-message-util: 24.9.0
       jest-mock: 24.9.0
       jest-regex-util: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       jest-snapshot: 24.9.0
       jest-util: 24.9.0
       jest-validate: 24.9.0
@@ -15460,7 +15449,7 @@ packages:
       jest-message-util: 26.3.0
       jest-mock: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       jest-snapshot: 26.3.0
       jest-util: 26.3.0
       jest-validate: 26.3.0
@@ -15498,7 +15487,7 @@ packages:
       jest-get-type: 24.9.0
       jest-matcher-utils: 24.9.0
       jest-message-util: 24.9.0
-      jest-resolve: 24.9.0
+      jest-resolve: 24.9.0_jest-resolve@24.9.0
       mkdirp: 0.5.5
       natural-compare: 1.4.0
       pretty-format: 24.9.0
@@ -15521,7 +15510,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-matcher-utils: 26.3.0
       jest-message-util: 26.3.0
-      jest-resolve: 26.3.0
+      jest-resolve: 26.3.0_jest-resolve@26.3.0
       natural-compare: 1.4.0
       pretty-format: 26.3.0
       semver: 7.3.2
@@ -16878,7 +16867,7 @@ packages:
       loader-utils: 1.4.0
       normalize-url: 1.9.1
       schema-utils: 1.0.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -17501,7 +17490,7 @@ packages:
     dependencies:
       loader-utils: 1.4.0
       schema-utils: 1.0.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     engines:
       node: '>= 8.9.0'
@@ -17809,7 +17798,7 @@ packages:
     dependencies:
       cssnano: 4.1.10
       last-call-webpack-plugin: 3.0.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     peerDependencies:
       webpack: ^4.0.0
@@ -22154,7 +22143,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -22174,7 +22163,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -22949,7 +22938,7 @@ packages:
       loader-utils: 1.4.0
       mime: 2.4.7
       schema-utils: 1.0.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
     dev: false
     engines:
       node: '>= 6.9.0'
@@ -23273,7 +23262,7 @@ packages:
       mime: 2.4.7
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-log: 2.0.0
     dev: false
     engines:
@@ -23313,7 +23302,7 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 4.44.2
+      webpack: 4.44.2_webpack@4.44.2
       webpack-dev-middleware: 3.7.3_webpack@4.44.2
       webpack-log: 2.0.0
       ws: 6.2.1
@@ -23373,7 +23362,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
-  /webpack/4.44.2:
+  /webpack/4.44.2_webpack@4.44.2:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -23403,6 +23392,7 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
+      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/solution/ui/gatsby-config.js
+++ b/solution/ui/gatsby-config.js
@@ -31,15 +31,6 @@ module.exports = {
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
-    {
-      resolve: `gatsby-plugin-manifest`,
-      options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
-        start_url: `/`,
-        display: `minimal-ui`
-      },
-    },
     'gatsby-plugin-eslint'
 
 

--- a/solution/ui/package.json
+++ b/solution/ui/package.json
@@ -10,7 +10,6 @@
     "gatsby-image": "^2.4.5",
     "gatsby-legacy-polyfills": "0.4.0",
     "gatsby-plugin-less": "^3.2.4",
-    "gatsby-plugin-manifest": "^2.4.9",
     "gatsby-plugin-offline": "^3.2.7",
     "gatsby-plugin-pnpm": "^1.2.5",
     "gatsby-plugin-react-helmet": "^3.3.2",


### PR DESCRIPTION
According to [Gatsby documentation](https://www.gatsbyjs.com/plugins/gatsby-plugin-manifest/) gatsby-plugin-manifest is 

> The web app manifest (part of the PWA specification) enabled by this plugin allows users to add your site to their home screen on most mobile browsers — see here. The manifest provides configuration and icons to the phone.

Our app is not a PWA, so we do not need this plugin. I removed it, and now we no longer have the console error.